### PR TITLE
Make ready for multiple engine usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ In this version all Geant3 gxxxxx routines have been renamed g3xxxxx.
 
 ### TGeant3 (Geant3 VMC)
 
+**IMPORTANT NOTE**: This version currently only works when building against [this ROOT version](https://github.com/benedikt-voelkel/root/tree/v6-14-06-multi-engines-wip-mgr)
+
 The directory TGeant3 contains the classes TGeant3 and TGeant3TGeo,
 which implement the  TVirtualMC interface, see more about VMC at: <br/>
 [https://root.cern.ch/vmc](https://root.cern.ch/vmc)
@@ -50,4 +52,3 @@ These scripts require the geant4_vmc file in a separate tar file.
 
 At present, the geant3 package is tested only using the test suites defined
 in geant4_vmc/examples.
-

--- a/TGeant3/TGeant3.cxx
+++ b/TGeant3/TGeant3.cxx
@@ -1092,7 +1092,6 @@ Gcjump_t *gcjump=0;          //! GCJUMP common structure
 // TVirtualMCApplication global pointer
 //
 TVirtualMCApplication* vmcApplication =0;
-TGeoBranchArray* gCurrentGeoState = 0;
 TMCParticleStatus* gCurrentParticleStatus = 0;
 // NOTE Use to control calls to TVirtualMCApplication::PreTrack
 //                                                   ::PostTrack
@@ -6833,23 +6832,20 @@ extern "C" void type_of_call  rxgtrak(Int_t &mtrack,Int_t &ipart,Float_t *pmom,
   gDoPostTrackHooks = kTRUE;
   gDoPrimaryHooks = kTRUE;
   gCurrentParticleStatus = 0;
-  gCurrentGeoState = 0;
   if (track) {
     TMCManagerStack* mcManagerStack = TVirtualMC::GetMC()->GetManagerStack();
     if(mcManagerStack) {
       gCurrentParticleStatus = const_cast<TMCParticleStatus*>(mcManagerStack->GetParticleStatus(mtrack));
-      gCurrentGeoState = (TGeoBranchArray*)mcManagerStack->GetGeoState(mtrack);
-    }
-    // NOTE Primary hooks need to be disabled explicitly since GEANT3 derives
-    //      that based on the stack structure and track counting. However, if
-    //      the VMC stack does not have the counting which is assumed by GEANT3,
-    //      the internal logic might not make the right concnlusion.
-    // TODO Make sure that primary hooks are called when necessary
-    if(gCurrentParticleStatus && gCurrentParticleStatus->fParentId >= 0) {
-      gDoPrimaryHooks = kFALSE;
-    }
-    if(gCurrentParticleStatus && gCurrentParticleStatus->fStepNumber > 0) {
-      gDoPreTrackHooks = kFALSE;
+      // NOTE Primary hooks need to be disabled explicitly since GEANT3 derives
+      //      that based on the stack structure and track counting.
+      // TODO However, if the VMC stack does not have the counting which is
+      //      assumed by GEANT3, the internal logic might not make the right concnlusion.
+      if(gCurrentParticleStatus->fParentId >= 0) {
+        gDoPrimaryHooks = kFALSE;
+      }
+      if(gCurrentParticleStatus->fStepNumber > 0) {
+        gDoPreTrackHooks = kFALSE;
+      }
       // fill G3 arrays
       pmom[0] = gCurrentParticleStatus->fMomentum.Px();
       pmom[1] = gCurrentParticleStatus->fMomentum.Py();
@@ -6862,7 +6858,7 @@ extern "C" void type_of_call  rxgtrak(Int_t &mtrack,Int_t &ipart,Float_t *pmom,
       polar[0] = gCurrentParticleStatus->fPolarization.X();
       polar[1] = gCurrentParticleStatus->fPolarization.Y();
       polar[2] = gCurrentParticleStatus->fPolarization.Z();
-      mcManagerStack->SetCurrentTrack(mtrack);
+
     } else {
       pmom[0] = track->Px();
       pmom[1] = track->Py();
@@ -6877,8 +6873,8 @@ extern "C" void type_of_call  rxgtrak(Int_t &mtrack,Int_t &ipart,Float_t *pmom,
       polar[0] = pol.X();
       polar[1] = pol.Y();
       polar[2] = pol.Z();
-      stack->SetCurrentTrack(mtrack);
     }
+    stack->SetCurrentTrack(mtrack);
     ipart = TVirtualMC::GetMC()->IdFromPDG(track->GetPdgCode());
   }
   mtrack++;

--- a/TGeant3/TGeant3.h
+++ b/TGeant3/TGeant3.h
@@ -697,6 +697,10 @@ public:
   Double_t TrackMass() const;
   Double_t TrackStep() const;
   Double_t TrackLength() const;
+  Int_t StepNumber() const;
+  Double_t TrackWeight() const;
+  void TrackPolarization(Double_t &polX, Double_t &polY, Double_t &polZ) const;
+  void TrackPolarization(TVector3& pol) const;
   Int_t   TrackPid() const;
   Bool_t IsNewTrack() const;
   Bool_t IsTrackInside() const;
@@ -714,6 +718,7 @@ public:
                       TLorentzVector &p);
   Bool_t SecondariesAreOrdered() const {return kTRUE;}
   void   StopTrack();
+  void   InterruptTrack();
   void   StopEvent();
   void   StopRun();
   Double_t MaxStep() const;
@@ -1135,10 +1140,13 @@ public:
   virtual void BuildPhysics();
   virtual void Init();
   virtual void ProcessEvent();
+  virtual void ProcessEvent(Int_t eventId, Bool_t isInterruptible = kFALSE);
   virtual Bool_t ProcessRun(Int_t nevent);
   virtual void AddParticlesToPdgDataBase() const;
   virtual void SetCollectTracks(Bool_t) {}
   Bool_t IsCollectTracks() const {return kFALSE;}
+
+
 
   //
   virtual void SetColors();

--- a/TGeant3/TGeant3TGeo.cxx
+++ b/TGeant3/TGeant3TGeo.cxx
@@ -522,7 +522,7 @@ extern "C" type_of_call void ggperpTGeo(Float_t*, Float_t*, Int_t&);
 //
 Gcvol1_t *gcvol1 = 0;
 TGeoNode *gCurrentNode = 0;
-extern TGeoBranchArray *gCurrentGeoState;
+extern TMCParticleStatus* gCurrentParticleStatus;
 TGeant3TGeo *geant3tgeo = 0;
 R__EXTERN Gctrak_t *gctrak;
 R__EXTERN Gcvolu_t *gcvolu;
@@ -2280,14 +2280,18 @@ void gtmediTGeo(Float_t *x, Int_t &numed)
 {
    gcchan->lsamvl = kTRUE;
    // Set cached geometry state if available, else find node manually.
-   if(gCurrentGeoState) {
-     gCurrentGeoState->UpdateNavigator(gGeoManager->GetCurrentNavigator());
-     gMC->GetManagerStack()->NotifyOnRestoredGeometry(gCurrentGeoState);
-     // Reset geo state index
-     gCurrentGeoState = 0;
-     gGeoManager->SetCurrentPoint(x[0],x[1],x[2]);
-     gCurrentNode = gGeoManager->GetCurrentNode();
-   } else {
+   TGeoBranchArray* geoState = 0;
+   if(gCurrentParticleStatus) {
+     TMCManagerStack* mcManagerStack = gMC->GetManagerStack();
+     geoState = (TGeoBranchArray*)mcManagerStack->GetCurrentGeoState();
+     if(geoState) {
+       geoState->UpdateNavigator(gGeoManager->GetCurrentNavigator());
+       mcManagerStack->NotifyOnRestoredGeometry();
+       gGeoManager->SetCurrentPoint(x[0],x[1],x[2]);
+       gCurrentNode = gGeoManager->GetCurrentNode();
+     }
+   }
+   if(!geoState) {
      gCurrentNode = gGeoManager->FindNode(x[0],x[1],x[2]);
    }
    gcchan->lsamvl = gGeoManager->IsSameLocation();
@@ -2312,16 +2316,20 @@ void gtmediTGeo(Float_t *x, Int_t &numed)
 void gmediaTGeo(Float_t *x, Int_t &numed, Int_t & /*check*/)
 {
   // Set cached geometry state if available, else find node manually.
-  if(gCurrentGeoState) {
-    gCurrentGeoState->UpdateNavigator(gGeoManager->GetCurrentNavigator());
-    gMC->GetManagerStack()->NotifyOnRestoredGeometry(gCurrentGeoState);
-    // Reset geo state index
-    gCurrentGeoState = 0;
-    gGeoManager->SetCurrentPoint(x[0],x[1],x[2]);
-    gCurrentNode = gGeoManager->GetCurrentNode();
-  } else {
-    gCurrentNode = gGeoManager->FindNode(x[0],x[1],x[2]);
-  }
+   TGeoBranchArray* geoState = 0;
+   if(gCurrentParticleStatus) {
+     TMCManagerStack* mcManagerStack = gMC->GetManagerStack();
+     geoState = (TGeoBranchArray*)mcManagerStack->GetCurrentGeoState();
+     if(geoState) {
+       geoState->UpdateNavigator(gGeoManager->GetCurrentNavigator());
+       mcManagerStack->NotifyOnRestoredGeometry();
+       gGeoManager->SetCurrentPoint(x[0],x[1],x[2]);
+       gCurrentNode = gGeoManager->GetCurrentNode();
+     }
+   }
+   if(!geoState) {
+     gCurrentNode = gGeoManager->FindNode(x[0],x[1],x[2]);
+   }
    if (gGeoManager->IsOutside()) {
       numed=0;
    } else {

--- a/TGeant3/TGeant3gu.cxx
+++ b/TGeant3/TGeant3gu.cxx
@@ -113,6 +113,8 @@
 extern TGeant3* geant3;
 extern TGeoManager *gGeoManager;
 extern TVirtualMCApplication* vmcApplication;
+extern Bool_t gDoPreTrackHooks;
+extern Bool_t gDoPostTrackHooks;
 
 extern "C" type_of_call void calsig();
 extern "C" type_of_call void gcalor();
@@ -555,12 +557,15 @@ void gutrak()
 //    ------------------------------------------------------------------
 //
      geant3->Gctrak()->istop = 0;
-
-     vmcApplication->PreTrack();
+     if(gDoPreTrackHooks) {
+       vmcApplication->PreTrack();
+     }
 
      g3track();
 
-     vmcApplication->PostTrack();
+     if(gDoPostTrackHooks) {
+       vmcApplication->PostTrack();
+     }
 }
 
 //______________________________________________________________________
@@ -892,8 +897,10 @@ void gukine ()
 //
 //    ------------------------------------------------------------------
 //
-
-  vmcApplication->GeneratePrimaries();
+  // NOTE Check whether particles are generated externally
+  if(!geant3->UseExternalParticleGeneration()) {
+    vmcApplication->GeneratePrimaries();
+  }
 }
 }
 // end of extern "C"


### PR DESCRIPTION
With this commit GEANT3 becomes capable of running together with other
engines sharing the simulation of one event. Depending on user
condistions, tracks might be transported by an engine based on geometry
constraints, particle type of phase space. When these conditions are not
met anymore, the VMC TMCManager interrupts the transport and transfers
the track to the engine responsible under the new conditions. This can
happen multiple times and is done automatically until all tracks have
been fully transported.