### PR TITLE
Make ready for multiple engine usage

### DIFF
--- a/TGeant3/TGeant3.cxx
+++ b/TGeant3/TGeant3.cxx
@@ -525,6 +525,7 @@ Cleanup of code
 #include "RVersion.h"
 
 #include "TGeant3.h"
+#include "TMCManager.h"
 #include "TMCManagerStack.h"
 #include "TMCParticleStatus.h"
 
@@ -1060,6 +1061,7 @@ Gcjump_t *gcjump = 0; //! GCJUMP common structure
 //
 TVirtualMCApplication *vmcApplication = 0;
 TMCParticleStatus *gCurrentParticleStatus = 0;
+TMCManager *gMCManager = 0;
 // NOTE Use to control calls to TVirtualMCApplication::PreTrack
 //                                                   ::PostTrack
 //                                                   ::BeginPrimary
@@ -1101,6 +1103,7 @@ TGeant3::TGeant3()
    //
    geant3 = this;
    vmcApplication = TVirtualMCApplication::Instance();
+   gMCManager = TMCManager::Instance();
 }
 
 //______________________________________________________________________
@@ -1128,6 +1131,7 @@ TGeant3::TGeant3(const char *title, Int_t nwgeant)
 
    geant3 = this;
    vmcApplication = TVirtualMCApplication::Instance();
+   gMCManager = TMCManager::Instance();
 
    if (nwgeant) {
       g3zebra(nwgeant);
@@ -2418,7 +2422,8 @@ void TGeant3::TrackPolarization(Double_t &polX, Double_t &polY, Double_t &polZ) 
    //
    // Return the current polarization
    //
-   // TODO Extract actual polarization
+   // NOTE Polarization, used in Geant3 for Cherenkov photons only,
+   //      not yet taken into account here
    polX = 0.;
    polY = 0.;
    polZ = 0.;
@@ -2430,7 +2435,8 @@ void TGeant3::TrackPolarization(TVector3 &pol) const
    //
    // Return the current polarization
    //
-   // TODO Extract actual polarization
+   // NOTE Polarization, used in Geant3 for Cherenkov photons only,
+   //      not yet taken into account here
    pol[0] = 0.;
    pol[1] = 0.;
    pol[2] = 0.;
@@ -5900,9 +5906,9 @@ void TGeant3::WriteEuclid(const char *filnam, const char *topvol, Int_t number, 
    iws[nvstak] = ivo;
    iws[iadvol + ivo] = level;
    ivstak = 0;
-//
-//*** flag all volumes and fill the stack
-//
+   //
+   //*** flag all volumes and fill the stack
+   //
 L10:
    //
    //    pick the next volume in stack
@@ -6462,7 +6468,7 @@ void TGeant3::Init()
    fApplication->AddParticles();
    fApplication->AddIons();
    // First, check whether geometry is constructed externally
-   if (!UseExternalGeometryConstruction()) {
+   if (!gMCManager) {
       fApplication->ConstructGeometry();
    }
    FinishGeometry();

--- a/TGeant3/TGeant3.h
+++ b/TGeant3/TGeant3.h
@@ -692,6 +692,10 @@ public:
    Double_t TrackMass() const;
    Double_t TrackStep() const;
    Double_t TrackLength() const;
+   Int_t StepNumber() const;
+   Double_t TrackWeight() const;
+   void TrackPolarization(Double_t &polX, Double_t &polY, Double_t &polZ) const;
+   void TrackPolarization(TVector3 &pol) const;
    Int_t TrackPid() const;
    Bool_t IsNewTrack() const;
    Bool_t IsTrackInside() const;
@@ -708,6 +712,7 @@ public:
    void GetSecondary(Int_t isec, Int_t &partPDG, TLorentzVector &x, TLorentzVector &p);
    Bool_t SecondariesAreOrdered() const { return kTRUE; }
    void StopTrack();
+   void InterruptTrack();
    void StopEvent();
    void StopRun();
    Double_t MaxStep() const;
@@ -1050,6 +1055,7 @@ public:
    virtual void BuildPhysics();
    virtual void Init();
    virtual void ProcessEvent();
+   virtual void ProcessEvent(Int_t eventId, Bool_t isInterruptible = kFALSE);
    virtual Bool_t ProcessRun(Int_t nevent);
    virtual void AddParticlesToPdgDataBase() const;
    virtual void SetCollectTracks(Bool_t) {}

--- a/TGeant3/TGeant3TGeo.cxx
+++ b/TGeant3/TGeant3TGeo.cxx
@@ -397,7 +397,6 @@ Cleanup of code
 #include "TGeant3TGeo.h"
 
 #include "TGeoManager.h"
-#include "TGeoBranchArray.h"
 #include "TGeoMatrix.h"
 #include "TGeoExtension.h"
 #include "TGeoMCGeometry.h"
@@ -521,7 +520,7 @@ extern "C" type_of_call void ggperpTGeo(Float_t *, Float_t *, Int_t &);
 Gcvol1_t *gcvol1 = 0;
 TGeoNode *gCurrentNode = 0;
 TGeant3TGeo *geant3tgeo = 0;
-TMCManager *mcManager = 0;
+extern TMCManager *gMCManager;
 extern TMCParticleStatus *gCurrentParticleStatus;
 
 R__EXTERN Gctrak_t *gctrak;
@@ -551,7 +550,6 @@ TGeant3TGeo::TGeant3TGeo()
    //
    // Default constructor
    geant3tgeo = this;
-   mcManager = TMCManager::Instance();
 }
 
 //____________________________________________________________________________
@@ -565,7 +563,6 @@ TGeant3TGeo::TGeant3TGeo(const char *title, Int_t nwgeant)
 
    SetName("TGeant3TGeo");
    geant3tgeo = this;
-   mcManager = TMCManager::Instance();
 
    fMCGeo = new TGeoMCGeometry("MCGeo", "TGeo Implementation of VirtualMCGeometry");
 
@@ -2272,7 +2269,7 @@ void gtmediTGeo(Float_t *x, Int_t &numed)
 {
    gcchan->lsamvl = kTRUE;
    // Set cached geometry state if available, else find node manually.
-   if (gCurrentParticleStatus && mcManager && mcManager->RestoreGeometryState(gCurrentParticleStatus->fId)) {
+   if (gCurrentParticleStatus && gMCManager && gMCManager->RestoreGeometryState(gCurrentParticleStatus->fId)) {
       gCurrentNode = gGeoManager->GetCurrentNode();
    } else {
       gCurrentNode = gGeoManager->FindNode(x[0], x[1], x[2]);
@@ -2299,7 +2296,7 @@ void gtmediTGeo(Float_t *x, Int_t &numed)
 void gmediaTGeo(Float_t *x, Int_t &numed, Int_t & /*check*/)
 {
    // Set cached geometry state if available, else find node manually.
-   if (gCurrentParticleStatus && mcManager && mcManager->RestoreGeometryState(gCurrentParticleStatus->fId)) {
+   if (gCurrentParticleStatus && gMCManager && gMCManager->RestoreGeometryState(gCurrentParticleStatus->fId)) {
       gCurrentNode = gGeoManager->GetCurrentNode();
    } else {
       gCurrentNode = gGeoManager->FindNode(x[0], x[1], x[2]);

--- a/TGeant3/TGeant3gu.cxx
+++ b/TGeant3/TGeant3gu.cxx
@@ -113,6 +113,8 @@
 extern TGeant3 *geant3;
 extern TGeoManager *gGeoManager;
 extern TVirtualMCApplication *vmcApplication;
+extern Bool_t gDoPreTrackHooks;
+extern Bool_t gDoPostTrackHooks;
 
 extern "C" type_of_call void calsig();
 extern "C" type_of_call void gcalor();
@@ -572,11 +574,15 @@ extern "C" type_of_call
       //
       geant3->Gctrak()->istop = 0;
 
-      vmcApplication->PreTrack();
+      if (gDoPreTrackHooks) {
+         vmcApplication->PreTrack();
+      }
 
       g3track();
 
-      vmcApplication->PostTrack();
+      if (gDoPostTrackHooks) {
+         vmcApplication->PostTrack();
+      }
    }
 
    //______________________________________________________________________
@@ -881,11 +887,10 @@ extern "C" type_of_call
             mom[0] = geant3->Gckin2()->xphot[jk][3] * geant3->Gckin2()->xphot[jk][6];
             mom[1] = geant3->Gckin2()->xphot[jk][4] * geant3->Gckin2()->xphot[jk][6];
             mom[2] = geant3->Gckin2()->xphot[jk][5] * geant3->Gckin2()->xphot[jk][6];
-            geant3->SetTrack(1, stack->GetCurrentTrackNumber(), geant3->PDGFromId(50),
-                             mom,                             // momentum
-                             geant3->Gckin2()->xphot[jk],     // position
-                             &geant3->Gckin2()->xphot[jk][7], // polarisation
-                             geant3->Gckin2()->xphot[jk][10], // time of flight
+            geant3->SetTrack(1, stack->GetCurrentTrackNumber(), geant3->PDGFromId(50), mom, // momentum
+                             geant3->Gckin2()->xphot[jk],                                   // position
+                             &geant3->Gckin2()->xphot[jk][7],                               // polarisation
+                             geant3->Gckin2()->xphot[jk][10],                               // time of flight
                              kPCerenkov, nt, 1., 0);
          }
       }
@@ -926,8 +931,10 @@ extern "C" type_of_call
       //
       //    ------------------------------------------------------------------
       //
-
-      vmcApplication->GeneratePrimaries();
+      if (!geant3->UseExternalParticleGeneration()) {
+         // Check whether particles are generated externally
+         vmcApplication->GeneratePrimaries();
+      }
    }
 }
 // end of extern "C"

--- a/TGeant3/TGeant3gu.cxx
+++ b/TGeant3/TGeant3gu.cxx
@@ -113,6 +113,7 @@
 extern TGeant3 *geant3;
 extern TGeoManager *gGeoManager;
 extern TVirtualMCApplication *vmcApplication;
+extern TMCManager *gMCManager;
 extern Bool_t gDoPreTrackHooks;
 extern Bool_t gDoPostTrackHooks;
 
@@ -887,10 +888,11 @@ extern "C" type_of_call
             mom[0] = geant3->Gckin2()->xphot[jk][3] * geant3->Gckin2()->xphot[jk][6];
             mom[1] = geant3->Gckin2()->xphot[jk][4] * geant3->Gckin2()->xphot[jk][6];
             mom[2] = geant3->Gckin2()->xphot[jk][5] * geant3->Gckin2()->xphot[jk][6];
-            geant3->SetTrack(1, stack->GetCurrentTrackNumber(), geant3->PDGFromId(50), mom, // momentum
-                             geant3->Gckin2()->xphot[jk],                                   // position
-                             &geant3->Gckin2()->xphot[jk][7],                               // polarisation
-                             geant3->Gckin2()->xphot[jk][10],                               // time of flight
+            geant3->SetTrack(1, stack->GetCurrentTrackNumber(), geant3->PDGFromId(50),
+                             mom,                             // momentum
+                             geant3->Gckin2()->xphot[jk],     // position
+                             &geant3->Gckin2()->xphot[jk][7], // polarisation
+                             geant3->Gckin2()->xphot[jk][10], // time of flight
                              kPCerenkov, nt, 1., 0);
          }
       }
@@ -931,7 +933,7 @@ extern "C" type_of_call
       //
       //    ------------------------------------------------------------------
       //
-      if (!geant3->UseExternalParticleGeneration()) {
+      if (!gMCManager) {
          // Check whether particles are generated externally
          vmcApplication->GeneratePrimaries();
       }

--- a/gtrak/gtreveroot.F
+++ b/gtrak/gtreveroot.F
@@ -77,16 +77,17 @@ C.    ------------------------------------------------------------------
 *
       MTRACK=-999
       FINISHPRIMA=0
-10    MTROLD=MTRACK
-      ISPRIMA=0
-      CALL RXGTRAK(MTRACK,IPART,PMOM,E,VPOS,VPOLA,TTOF,ISPRIMA)
-* Finish primary track if flagged
+10    ISPRIMA=0
       IF(FINISHPRIMA.GE.1) THEN
          CALL RXOUTH
          FINISHPRIMA=0
       ENDIF
-
-      IF(MTRACK.LE.0) GOTO 999
+      CALL RXGTRAK(MTRACK,IPART,PMOM,E,VPOS,VPOLA,TTOF,ISPRIMA)
+* Finish primary track if flagged
+      IF(MTRACK.LE.0) THEN
+         FINISHPRIMA=0
+         GOTO 999
+      ENDIF
 
       IF(ISPRIMA.GE.1) THEN
          CALL RXINH


### PR DESCRIPTION
With this commit GEANT3 becomes capable of running together with other
engines sharing the simulation of one event. Depending on user
conditions, tracks might be transported by an engine based on geometry
constraints, particle type of phase space. When these conditions are not
met anymore, the VMC TMCManager interrupts the transport and transfers
the track to the engine responsible under the new conditions. This can
happen multiple times and is done automatically until all tracks have
been fully transported.