### PR TITLE
Upgrade CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 endif()
 
 #--- Define CMake requirements -------------------------------------------------
-cmake_minimum_required(VERSION 2.6.4 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
 
 #--- Prepend our own CMake Modules to the search path --------------------------
 set(CMAKE_MODULE_PATH

--- a/cmake/Geant3BuildLibrary.cmake
+++ b/cmake/Geant3BuildLibrary.cmake
@@ -136,20 +136,6 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND APPLE)
       "${CMAKE_SHARED_LINKER_FLAGS} -undefined dynamic_lookup -Wl,-no_compact_unwind")
 endif()
 
-# Determine CXX STD from ROOT
-SET(CMAKE_CXX_STANDARD 11)
-# Find ROOT CXX standard
-string(FIND ${ROOT_CXX_FLAGS} "-std=" POSITION)
-if (${POSITION} GREATER -1)
-    string(SUBSTRING ${ROOT_CXX_FLAGS} ${POSITION} 11 ROOT_CXX_STD)
-    if(${ROOT_CXX_STD} STREQUAL "-std=c++1z " OR ${ROOT_CXX_STD} STREQUAL "-std=c++17 ")
-        SET(CMAKE_CXX_STANDARD 17)
-    elseif(${ROOT_CXX_STD} STREQUAL "-std=c++1y " OR ${ROOT_CXX_STD} STREQUAL "-std=c++14 ")
-        SET(CMAKE_CXX_STANDARD 14)
-    endif()
-endif()
-message(STATUS "Build with CXX STD ${CMAKE_CXX_STANDARD}")
-
 #---Add library-----------------------------------------------------------------
 add_library(${library_name} ${fortran_sources} ${c_sources} ${cxx_sources}
             ${root_dict} ${headers})

--- a/cmake/Geant3BuildProject.cmake
+++ b/cmake/Geant3BuildProject.cmake
@@ -64,5 +64,5 @@ install(FILES
   "${PROJECT_BINARY_DIR}/Geant3ConfigVersion.cmake"
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/Geant3-${Geant3_VERSION})
 
-install(EXPORT Geant3Targets NAMESPACE GEANT3_VMC::
+install(EXPORT Geant3Targets
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/Geant3-${Geant3_VERSION})

--- a/cmake/Geant3BuildProject.cmake
+++ b/cmake/Geant3BuildProject.cmake
@@ -64,5 +64,5 @@ install(FILES
   "${PROJECT_BINARY_DIR}/Geant3ConfigVersion.cmake"
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/Geant3-${Geant3_VERSION})
 
-install(EXPORT Geant3Targets
+install(EXPORT Geant3Targets NAMESPACE GEANT3_VMC::
   DESTINATION ${CMAKE_INSTALL_LIBDIR}/Geant3-${Geant3_VERSION})

--- a/cmake/Geant3Config.cmake.in
+++ b/cmake/Geant3Config.cmake.in
@@ -20,7 +20,7 @@ get_filename_component(_dir "${CMAKE_CURRENT_LIST_FILE}" PATH)
 get_filename_component(_prefix "${_dir}/../.." ABSOLUTE)
 
 # Import targets
-include("${_prefix}/@CMAKE_INSTALL_LIBDIR@/Geant3-@Geant3_VERSION@/Geant3Targets.cmake")
+include("${_dir}/Geant3Targets.cmake")
  
 # Import options
 set(Geant3_CMAKE_INSTALL_LIBDIR @CMAKE_INSTALL_LIBDIR@)

--- a/cmake/Geant3RequiredPackages.cmake
+++ b/cmake/Geant3RequiredPackages.cmake
@@ -13,10 +13,9 @@
 # I. Hrivnacova, 15/04/2019
 
 #-- ROOT (required) ------------------------------------------------------------
-find_package(ROOT CONFIG REQUIRED)
-set(ROOT_DEPS ROOT::Core ROOT::RIO ROOT::Net ROOT::Hist ROOT::Graf ROOT::Graf3d ROOT::Gpad
-    ROOT::Tree ROOT::Rint ROOT::Postscript ROOT::Matrix ROOT::Physics ROOT::MathCore
-    ROOT::Thread ROOT::Geom ROOT::EG)
+find_package(ROOT CONFIG COMPONENTS EG Geom REQUIRED)
+set(ROOT_DEPS ROOT::Core ROOT::RIO ROOT::Tree ROOT::Rint ROOT::Physics
+    ROOT::MathCore ROOT::Thread ROOT::Geom ROOT::EG)
 include(${ROOT_USE_FILE})
 
 #-- VMC (required) ------------------------------------------------------------

--- a/cmake/Geant3RequiredPackages.cmake
+++ b/cmake/Geant3RequiredPackages.cmake
@@ -14,21 +14,23 @@
 
 #-- ROOT (required) ------------------------------------------------------------
 find_package(ROOT CONFIG REQUIRED)
+set(ROOT_DEPS ROOT::Core ROOT::RIO ROOT::Net ROOT::Hist ROOT::Graf ROOT::Graf3d ROOT::Gpad
+    ROOT::Tree ROOT::Rint ROOT::Postscript ROOT::Matrix ROOT::Physics ROOT::MathCore
+    ROOT::Thread ROOT::Geom ROOT::EG)
 include(${ROOT_USE_FILE})
-set (ROOT_LIBRARIES ${ROOT_LIBRARIES} -lEG -lGeom)
 
 #-- VMC (required) ------------------------------------------------------------
 if(ROOT_vmc_FOUND)
   message(STATUS "Using VMC built with ROOT")
-  set(VMC_LIBRARIES "VMC")
+  set(VMC_DEPS ROOT::VMC)
   message(STATUS "Adding -DUSE_ROOT_VMC")
   add_definitions(-DUSE_ROOT_VMC)
 else()
   #-- VMC (required) ------------------------------------------------------------
   find_package(VMC CONFIG REQUIRED)
+  set(VMC_DEPS VMC::VMCLibrary)
   if(NOT VMC_FIND_QUIETLY)
     message(STATUS "Found VMC ${VMC_VERSION} in ${VMC_DIR}")
-    #message(STATUS VMC_INCLUDE_DIRS ${VMC_INCLUDE_DIRS})
-    #message(STATUS VMC_LIBRARIES ${VMC_LIBRARIES})
   endif()
 endif()
+

--- a/cmake/Geant3RequiredPackages.cmake
+++ b/cmake/Geant3RequiredPackages.cmake
@@ -33,4 +33,3 @@ else()
     message(STATUS "Found VMC ${VMC_VERSION} in ${VMC_DIR}")
   endif()
 endif()
-

--- a/cmake/Geant3RequiredPackages.cmake
+++ b/cmake/Geant3RequiredPackages.cmake
@@ -28,7 +28,7 @@ if(ROOT_vmc_FOUND)
 else()
   #-- VMC (required) ------------------------------------------------------------
   find_package(VMC CONFIG REQUIRED)
-  set(VMC_DEPS VMC::VMCLibrary)
+  set(VMC_DEPS VMCLibrary)
   if(NOT VMC_FIND_QUIETLY)
     message(STATUS "Found VMC ${VMC_VERSION} in ${VMC_DIR}")
   endif()


### PR DESCRIPTION
Find ROOT and VMC always by their CMake config and use aliased/namespace
library names ROOT:: and VMC::, respectively, when linking GEANT3
targets. This also avoids hard-coded library paths in the CMake targets.

Add libraries used to build GEANT3 to CMake target file making it
properties of the GEANT3 library target along with its include path.
This makes it straightforward to be used in other package linking
against GEANT3_VMC.

Introduce namespace GEANT3_VMC:: for GEANT3 targets.

N.B. As there were hard-coded paths in the GEANT3 CMake target files,
re-location errors occur if GEANT3 is used from pre-built binaries.