### PR TITLE
Fix for segmentation violation (MacOS 10.15.4)

### DIFF
--- a/gcons/gstmed.F
+++ b/gcons/gstmed.F
@@ -116,7 +116,7 @@
       EQUIVALENCE (MECA(1,1),IPAIR)
       DIMENSION UBUF(1),CUTVEC(10)
       EQUIVALENCE (CUTVEC,CUTGAM)
-      CHARACTER*(*) NATMED
+      CHARACTER*20 NATMED
       CHARACTER*20 NAME
 C.
 C.    ------------------------------------------------------------------


### PR DESCRIPTION
We observed a segmentation violation on the MacOS build and test infrastructure (AliRoot/test/gun). It is probably caused by some gfortran 9.3.0 features, the fix solves this issue.