### PR TITLE
Fix floating point roundoff error in addressing the zebra array.

### DIFF
--- a/gphys/gphsg1.F
+++ b/gphys/gphsg1.F
@@ -49,16 +49,16 @@ C.
       IF(E.LT.G10EV) GO TO 20
 C Use Sandia data
       JPHXS = LQ(JPHOT-1)
-      IPOINT = JPHXS+Q(JPHXS+1)*3+2
-      IMAX = Q(IPOINT)
+      IPOINT = Q(JPHXS+1)*3+2
+      IMAX = Q(jphxs+IPOINT)
       IPOINT = IPOINT+1
       ECUR = E*1.E6
-      IF(ECUR.LT.Q(IPOINT)) GO TO 20
+      IF(ECUR.LT.Q(jphxs+IPOINT)) GO TO 20
       EINV = ONE/ECUR
       DO 10 I = 2,IMAX
          IPOINT = IPOINT+5
-         IF(ECUR.LT.Q(IPOINT)) THEN
-            J = IPOINT+1
+         IF(ECUR.LT.Q(jphxs+IPOINT)) THEN
+            J = jphxs+IPOINT+1
             RES = EINV*(Q(J)+EINV*(Q(J+1)+EINV*(Q(J+2)+EINV*Q(J+3))))
             GO TO 20
          ENDIF


### PR DESCRIPTION
We discovered an issue with our (non-VMC) GEANT3 application where some of the photoelectric cross section tables were not filled.  We tracked this down to the initialization code.  On line 53, the location of the last entry of the sandia data table within the Q array is calculated.  The problem arises because the expression on the right involves floating point, rather than integer, arithmetic.  It is illustrated with the following test program using input values which we saw fail--

```
      PROGRAM DemoZebraIssue
      INTEGER :: jphxs = 19323875
      REAL    :: Qr    = 2.0
      REAL*8  :: Qd    = 2.0
      INTEGER :: Qi    = 2
      
      INTEGER :: ipoint1, ipoint2, ipoint3

      ipoint1 = jphxs + Qr*3 + 2
      ipoint2 = jphxs + Qd*3 + 2
      ipoint3 = jphxs + Qi*3 + 2

      write (*,*) '[REAL*4  Q] ipoint = ', ipoint1
      write (*,*) '[REAL*8  Q] ipoint = ', ipoint2
      write (*,*) '[INTEGER Q] ipoint = ', ipoint3

      END
```

$ uname -a
Linux peregrine 5.3.0-59-generic #53~18.04.1-Ubuntu SMP Thu Jun 4 14:58:26 UTC 2020 x86_64 x86_64 x86_64 GNU/Linux

$ gfortran point.F
$ ./a.out
 [REAL*4  Q] ipoint =     19323884
 [REAL*8  Q] ipoint =     19323883
 [INTEGER Q] ipoint =     19323883

The result is that the array is referenced at the wrong location, leading to an incorrect  loop termination at IMAX = Q(ipoint) = 0.

The proposed fix ensures that the JPHXS offset is added using integer, rather than floating point, arithmetic. 



