### PR TITLE
Allow non-standard-conform BOZ literal constants in GCC >=10

### DIFF
--- a/cmake/Geant3BuildLibrary.cmake
+++ b/cmake/Geant3BuildLibrary.cmake
@@ -113,6 +113,11 @@ file(GLOB headers ${PROJECT_SOURCE_DIR}/TGeant3/*.h)
 add_definitions(-DCERNLIB_BLDLIB -DCERNLIB_CZ)
 # add flags to make gfortran build stable at -O2
 set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -finit-local-zero -fno-strict-overflow")
+# allow non-standard-conform BOZ literal constants in GCC >=10
+if (        "${CMAKE_Fortran_COMPILER_ID}" STREQUAL "GNU"
+    AND NOT "${CMAKE_Fortran_COMPILER_VERSION}" VERSION_LESS 10)
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fallow-invalid-boz")
+endif()
 # Architecture dependent not ported flags:
 # -DCERNLIB_LINUX (linux, linuxx8664icc, linuxicc, macosx, macosxxlc, macosicc)
 # -DCERNLIB_PPC (macosx64, macosxxlc, macosicc)


### PR DESCRIPTION
-fallow-invalid-boz

A BOZ literal constant can occur in a limited number of contexts in standard
conforming Fortran. This option degrades an error condition to a warning, and
allows a BOZ literal constant to appear where the Fortran standard would
otherwise prohibit its use.

see https://gcc.gnu.org/onlinedocs/gfortran/Fortran-Dialect-Options.html

fix #17

---

FYI: I did not use CMake's `VERSION_GREATER_EQUAL` operator because it was only introduced in CMake 3.7+ and the project requires only 2.8.

The condition works as intended for me on (all with ROOT 6.22):

| **OS** | **`gfortran --version`** | **`cmake --version`** |
| --- | --- | --- |
| Fedora 32 | GNU Fortran (GCC) 10.2.1 20200723 (Red Hat 10.2.1-1) | cmake version 3.17.4 |
| Fedora 31 | GNU Fortran (GCC) 9.3.1 20200408 (Red Hat 9.3.1-2) | cmake version 3.17.4 |
| Ubuntu 18.04 | GNU Fortran (Ubuntu 7.5.0-3ubuntu1~18.04) 7.5.0 | cmake version 3.10.2 |
| Centos 7 (cmake3 from EPEL) | GNU Fortran (GCC) 4.8.5 20150623 (Red Hat 4.8.5-39) | cmake3 version 3.17.3 |