### PR TITLE
Solve problem with Geane propagator

### DIFF
--- a/TGeant3/TGeant3.cxx
+++ b/TGeant3/TGeant3.cxx
@@ -5512,7 +5512,7 @@ void TGeant3::Ertrgo()
 
 //______________________________________________________________________
 void TGeant3::Ertrak(const Float_t *x1, const Float_t *p1, const Float_t *x2, const Float_t *p2, Int_t ipa,
-                     Option_t *chopt)
+                     const char *chopt)
 {
    //************************************************************************
    //*                                                                      *

--- a/TGeant3/TGeant3.h
+++ b/TGeant3/TGeant3.h
@@ -1028,7 +1028,7 @@ public:
 
    virtual void Ertrgo();
    virtual void
-   Ertrak(const Float_t *x1, const Float_t *p1, const Float_t *x2, const Float_t *p2, Int_t ipa, Option_t *chopt);
+   Ertrak(const Float_t *x1, const Float_t *p1, const Float_t *x2, const Float_t *p2, Int_t ipa,  const char *chopt);
    virtual void Erxyzc();
    virtual void Eufill(Int_t n, Float_t *ein, Float_t *xlf);
    virtual void Eufilp(const Int_t n, Float_t *ein, Float_t *pli, Float_t *plf);


### PR DESCRIPTION
Using Option_t  in Ertrak cause an inconsistent character options error
on the FORTRAN side (On MAC OS), using const char instead of Option_t solve the problem 