### PR TITLE
Fix the error in ertrak.F

### DIFF
--- a/erdecks/ertrak.F
+++ b/erdecks/ertrak.F
@@ -78,8 +78,8 @@
 *     
 * *** Decode character option
 *
-      CHOPTI = CHOPT
-      CALL UOPTC (CHOPT, 'BELMOPVX', IOPT)
+      CHOPTI = CHOPT(1:len(CHOPT))
+      CALL UOPTC (CHOPTI, 'BELMOPVX', IOPT)
 *
       IF (IOPTB.EQ.0) THEN
          BACKTR = 1.


### PR DESCRIPTION
Fix the problem with string as function argument.
The error was causing wrong string recognition, and, occasionally,
a segmentation violation.