### PR TITLE
gcalor: Fix gfortran 7 compilation

### DIFF
--- a/gcalor/gcalor.F
+++ b/gcalor/gcalor.F
@@ -15037,7 +15037,7 @@ C only p = 0, D = 7, T = 8, He3 = 9, alpha=10
      +                                0 , 7 , 8 , -1,
      +                               -1 ,-1 , 9 , 10/
       LOGICAL NOP
-      SAVE
+C      SAVE
 C first check, if ZEBRA still in order
       IF(LD(LMAG1).NE.NMAGIC.OR.LD(LMAG2).NE.NMAGIC) THEN
          WRITE(6,*) ' CALOR: ZEBRA banks screwed up --> STOP'


### PR DESCRIPTION
This error happens on CentOS7 with devtoolset-7:

```
geant3/gcalor/gcalor.F:14976:19:

       EQUIVALENCE (Q(1),IQ(1),LQ(9)),(LQ(1),LMAIN),(IWS(1),WS(1))
                   1
Error: COMMON attribute conflicts with SAVE attribute in 'q' at (1)
```

Discussion: https://github.com/alisw/alidist/issues/1345

```
Co-authored-by: Mohammad Al-Turany <MohammadAlTurany@users.noreply.github.com>
```