### PR TITLE
Further completion of ProcessEvent interfaces

### DIFF
--- a/TGeant3/TGeant3.cxx
+++ b/TGeant3/TGeant3.cxx
@@ -6544,9 +6544,7 @@ void TGeant3::ProcessEvent()
    //
    // Process one event
    //
-   Gtrigi();
-   Gtrigc();
-   Gtrig();
+   ProcessEvent(fGcflag->idevt);
 }
 
 //______________________________________________________________________


### PR DESCRIPTION
* actually implement TGeant3::ProcessEvent() since it is trivial.
  ProcessRun(int) also already relies on ProcessEvent(int, bool) in any case