### PR TITLE
Fix linking on macosx12

### DIFF
--- a/cmake/Geant3RequiredPackages.cmake
+++ b/cmake/Geant3RequiredPackages.cmake
@@ -15,7 +15,7 @@
 #-- ROOT (required) ------------------------------------------------------------
 find_package(ROOT CONFIG COMPONENTS EG Geom REQUIRED)
 set(ROOT_DEPS ROOT::Core ROOT::RIO ROOT::Tree ROOT::Rint ROOT::Physics
-    ROOT::MathCore ROOT::Thread ROOT::Geom ROOT::EG)
+    ROOT::MathCore ROOT::Thread ROOT::Geom ROOT::EG ROOT::EGPythia6)
 include(${ROOT_USE_FILE})
 
 #-- VMC (required) ------------------------------------------------------------


### PR DESCRIPTION
The problems does not appear during the actual linking but at runtime when
loading the library. In this case the dynamic linker isn"t able to find the
needed pythia6 library to resolve all symbols. This problem is fixed by adding
a new dependency to libEGpythia6 which itself depends on pythia6. This
indirect dependency avoids adding a macro which directly searches for pyhia6.