### PR TITLE
Make sure that TGeo is using the old Root units

### DIFF
--- a/TGeant3/TGeant3TGeo.cxx
+++ b/TGeant3/TGeant3TGeo.cxx
@@ -2156,6 +2156,16 @@ void TGeant3TGeo::FinishGeometry()
       printf("FinishGeometry, returning\n");
 }
 
+//______________________________________________________________________
+void TGeant3TGeo::Init()
+{
+   // Set Root default units to TGeo
+   TGeoManager::LockDefaultUnits(false);
+   TGeoManager::SetDefaultUnits(TGeoManager::kRootUnits);
+
+   TGeant3::Init();
+}
+
 #if ROOT_VERSION_CODE >= ROOT_VERSION(6, 14, 0)
 //_____________________________________________________________________________
 void TGeant3TGeo::SetSensitiveDetector(const TString &volumeName, TVirtualMCSensitiveDetector *userSD)

--- a/TGeant3/TGeant3TGeo.cxx
+++ b/TGeant3/TGeant3TGeo.cxx
@@ -2159,9 +2159,12 @@ void TGeant3TGeo::FinishGeometry()
 //______________________________________________________________________
 void TGeant3TGeo::Init()
 {
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 22, 8)
    // Set Root default units to TGeo
    TGeoManager::LockDefaultUnits(false);
    TGeoManager::SetDefaultUnits(TGeoManager::kRootUnits);
+   TGeoManager::LockDefaultUnits(true);
+#endif
 
    TGeant3::Init();
 }

--- a/TGeant3/TGeant3TGeo.h
+++ b/TGeant3/TGeant3TGeo.h
@@ -193,6 +193,7 @@ public:
    // Control Methods
 
    virtual void FinishGeometry();
+   virtual void Init();
 
    // methods for sensitive detectors
    virtual void SetSensitiveDetector(const TString &volumeName, TVirtualMCSensitiveDetector *sd);


### PR DESCRIPTION
The default TGeo units (cm, s, GeV) has been changed in Root v6.24
to Geant4 defaults (mm, ns, MeV); this setting affects setting of
material properties in TGeant3 (radlen)