### PR TITLE
Use size_t corresponding to the return type of strlen

### DIFF
--- a/TGeant3/TCallf77.h
+++ b/TGeant3/TCallf77.h
@@ -8,7 +8,7 @@
 #ifndef WIN32
 #define type_of_call
 #define DEFCHARD const char *
-#define DEFCHARL , const int
+#define DEFCHARL , size_t
 #define PASSCHARD(string) string
 #define PASSCHARL(string) , strlen(string)
 #else


### PR DESCRIPTION
This fixes a segmentation violation observed on MacOSX with M1/M2 processors.