### PR TITLE
Removed dependencies on pythia6:

### DIFF
--- a/cmake/Geant3BuildLibrary.cmake
+++ b/cmake/Geant3BuildLibrary.cmake
@@ -91,6 +91,9 @@ endif()
 list(REMOVE_ITEM fortran_sources ${PROJECT_SOURCE_DIR}/gtrak/grndm.F)
 list(REMOVE_ITEM fortran_sources ${PROJECT_SOURCE_DIR}/gtrak/grndmq.F)
 list(REMOVE_ITEM fortran_sources ${PROJECT_SOURCE_DIR}/erdecks/eustep.F)
+list(REMOVE_ITEM fortran_sources ${PROJECT_SOURCE_DIR}/gkine/gludky.F)
+list(REMOVE_ITEM fortran_sources ${PROJECT_SOURCE_DIR}/gkine/glund.F)
+list(REMOVE_ITEM fortran_sources ${PROJECT_SOURCE_DIR}/gkine/glundi.F)
 #message(STATUS "fortran_sources ${fortran_sources}")
 
 # C sources

--- a/cmake/Geant3RequiredPackages.cmake
+++ b/cmake/Geant3RequiredPackages.cmake
@@ -19,8 +19,10 @@ if(ROOT_vmc_FOUND)
   message(FATAL_ERROR
           "Cannot use VMC standalone with ROOT built with vmc.")
 endif()
+#set(ROOT_DEPS ROOT::Core ROOT::RIO ROOT::Tree ROOT::Rint ROOT::Physics
+#    ROOT::MathCore ROOT::Thread ROOT::Geom ROOT::EG ROOT::EGPythia6)
 set(ROOT_DEPS ROOT::Core ROOT::RIO ROOT::Tree ROOT::Rint ROOT::Physics
-    ROOT::MathCore ROOT::Thread ROOT::Geom ROOT::EG ROOT::EGPythia6)
+    ROOT::MathCore ROOT::Thread ROOT::Geom ROOT::EG)
 include(${ROOT_USE_FILE})
 
 #-- VMC (required) ------------------------------------------------------------


### PR DESCRIPTION
- Excluded `gludky.F, glund.F, glundi.F` from compilation
- Removed `ROOT::EGPythia6` from `ROOT_DEPS` in cmake configuration

The `pythia6` interface is deprecated in ROOT since version 6.30 (see https://root.cern/doc/v630/release-notes.html)

