### PR TITLE
Allow building with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
 endif()
 
 #--- Define CMake requirements -------------------------------------------------
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 #--- Prepend our own CMake Modules to the search path --------------------------
 set(CMAKE_MODULE_PATH

--- a/cmake/Geant3BuildLibrary.cmake
+++ b/cmake/Geant3BuildLibrary.cmake
@@ -11,7 +11,7 @@
 # I. Hrivnacova, 13/06/2014
 
 #---CMake required version -----------------------------------------------------
-cmake_minimum_required(VERSION 2.8.12 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
 #-------------------------------------------------------------------------------
 # Define installed names


### PR DESCRIPTION
Minimum requirement on CMake 2.8.x has been deprecated by the new CMake.