### PR TITLE
Adding VMC_DEPS setting in Geant3RequiredPackages

### DIFF
--- a/cmake/Geant3RequiredPackages.cmake
+++ b/cmake/Geant3RequiredPackages.cmake
@@ -27,3 +27,4 @@ include(${ROOT_USE_FILE})
 
 #-- VMC (required) ------------------------------------------------------------
 find_package(VMC CONFIG REQUIRED)
+set(VMC_DEPS ${VMC_LIBRARIES})


### PR DESCRIPTION
- This fixes linking error (missing symbols from VMC)